### PR TITLE
feat(memory): add unevictable flag API support

### DIFF
--- a/src/agent_runtime.zig
+++ b/src/agent_runtime.zig
@@ -271,7 +271,7 @@ pub const AgentRuntime = struct {
         );
         defer self.allocator.free(payload);
 
-        var created = try self.active_memory.create(brain_name, .ram, null, "message", payload);
+        var created = try self.active_memory.create(brain_name, .ram, null, "message", payload, false);
         created.deinit(self.allocator);
     }
 
@@ -401,7 +401,7 @@ pub const AgentRuntime = struct {
 
         // Store results as artifacts
         for (results) |result| {
-            var artifact = try self.active_memory.create(brain_name, .ram, null, "tool_result", result.payload_json);
+            var artifact = try self.active_memory.create(brain_name, .ram, null, "tool_result", result.payload_json, false);
             artifact.deinit(self.allocator);
         }
 

--- a/src/runtime_server.zig
+++ b/src/runtime_server.zig
@@ -893,7 +893,7 @@ pub const RuntimeServer = struct {
         const content_json = try payload.toOwnedSlice(self.allocator);
         defer self.allocator.free(content_json);
 
-        var created = try self.runtime.active_memory.create(brain_name, .ram, null, "message", content_json);
+        var created = try self.runtime.active_memory.create(brain_name, .ram, null, "message", content_json, false);
         created.deinit(self.allocator);
     }
 


### PR DESCRIPTION
- Update RuntimeMemory.create() to accept unevictable parameter
- Update memory.create brain tool to support optional 'unevictable' field
- Identity memories created with unevictable=true during hatch
- Regular memories default to unevictable=false
- Updated all callers to pass appropriate unevictable value
- RuntimeMemory.evict() now refuses to evict unevictable memories