### PR TITLE
fix(install): Build CLI and TUI separately

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -179,7 +179,7 @@ if [[ "$INSTALL_ZSS" == "true" ]]; then
     fi
     
     log_info "Building ZiggyStarSpider CLI..."
-    zig build -Doptimize=ReleaseSafe -Dtarget=native
+    zig build cli -Doptimize=ReleaseSafe -Dtarget=native
     
     log_info "Building ZiggyStarSpider TUI..."
     zig build tui -Doptimize=ReleaseSafe -Dtarget=native
@@ -187,7 +187,8 @@ if [[ "$INSTALL_ZSS" == "true" ]]; then
     log_info "Installing zss binaries..."
     cp zig-out/bin/zss "$INSTALL_DIR/" 2>/dev/null || true
     cp zig-out/bin/zss-tui "$INSTALL_DIR/" 2>/dev/null || true
-    # Note: zss-gui is built but not installed (headless server)
+    
+    log_success "ZiggyStarSpider installed!"
     
     log_success "ZiggyStarSpider installed!"
 fi


### PR DESCRIPTION
Now uses 'zig build cli' and 'zig build tui' separately. This avoids building GUI which is not needed on headless servers.