### PR TITLE
fix(install-zss): Stash local changes before git pull

### DIFF
--- a/install-zss.sh
+++ b/install-zss.sh
@@ -55,6 +55,8 @@ fi
 if [[ -d "$ZSS_REPO" ]]; then
     log_info "Updating ZiggyStarSpider..."
     cd "$ZSS_REPO"
+    # Stash any local changes to avoid merge conflicts
+    git stash -q 2>/dev/null || true
     git pull -q
 else
     log_info "Cloning ZiggyStarSpider (this may take a minute)..."


### PR DESCRIPTION
Prevents 'Your local changes would be overwritten' error when updating existing zss install that has local modifications.