### PR TITLE
Bump ZiggyPiAi master after PR #1 merge

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.13.0",
     .dependencies = .{
         .ziggy_piai = .{
-            .url = "https://github.com/DeanoC/ZiggyPiAi/archive/fa48d528f215bb43e1aae5e804360720141b2e92.tar.gz",
-            .hash = "N-V-__8AAHDqCgA6nRU9iXAG3SM_fNBpOmEjn33DbX4eAN-m",
+            .url = "https://github.com/DeanoC/ZiggyPiAi/archive/refs/heads/master.tar.gz",
+            .hash = "N-V-__8AAFjyCgCnfD3PlWDmlBaYQ0YKwV1Amch11cZw7BHK",
         },
     },
     .paths = .{


### PR DESCRIPTION
## Summary
- update `ziggy_piai` dependency URL to `refs/heads/master.tar.gz`
- refresh dependency hash to pick up merged ZiggyPiAi PR #1 fixes (including the follow-up compatibility gate fix)

## Validation
- `zig build`
- `zig build test`
