### PR TITLE
refactor: consume hook primitives from ziggy-runtime-hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Spiderweb now imports shared modules directly:
 - `ziggy-spider-protocol`
 - `ziggy-memory-store`
 - `ziggy-tool-runtime`
-- `ziggy-runtime-hooks` (wave-2 extraction started with `event_bus`)
+- `ziggy-runtime-hooks` (wave-2 extraction now includes `event_bus` and `hook_primitives`)
 
 Compatibility wrapper files (`src/protocol*.zig`, `src/memory*.zig`, `src/run_store.zig`, `src/tool_*.zig`) were marked for removal on February 22, 2026 with a target of `v0.3.0`, and are now removed. Use direct module imports in new code.
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -21,8 +21,8 @@
             .hash = "ziggy_tool_runtime-0.1.0-t8uaSEGuAACsRd_CxS3bTmnodmeUo1SYpBDONhrphUit",
         },
         .ziggy_runtime_hooks = .{
-            .url = "https://github.com/DeanoC/ZiggyRuntimeHooks/archive/refs/tags/v0.1.0.tar.gz",
-            .hash = "ziggy_runtime_hooks-0.1.0-68kKIJYrAAB7dK_N4JV7gRrkvgL6aaxSRXhiG2xJbydt",
+            .url = "https://github.com/DeanoC/ZiggyRuntimeHooks/archive/refs/tags/v0.2.1.tar.gz",
+            .hash = "ziggy_runtime_hooks-0.2.1-68kKICc9AAALrXImDGgdRh8g-c0-LKYge8XRY_dA5tvf",
         },
     },
     .paths = .{


### PR DESCRIPTION
## Summary\n- update ziggy_runtime_hooks dependency to v0.2.1\n- move HookPhase/HookError/HookPriority/CorePrompt/PendingTools to shared module\n- wire Spiderweb hook_registry to consume shared hook_primitives\n\n## Validation\n- zig build\n- zig build test\n