### PR TITLE
refactor: adopt hook registry engine from ziggy-runtime-hooks v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ Spiderweb now imports shared modules directly:
 - `ziggy-spider-protocol`
 - `ziggy-memory-store`
 - `ziggy-tool-runtime`
-- `ziggy-runtime-hooks` (wave-2 extraction now includes `event_bus` and `hook_primitives`)
+- `ziggy-runtime-hooks` (wave-2 extraction now includes `event_bus`, `hook_primitives`, and `hook_registry_engine`)
 
 Compatibility wrapper files (`src/protocol*.zig`, `src/memory*.zig`, `src/run_store.zig`, `src/tool_*.zig`) were marked for removal on February 22, 2026 with a target of `v0.3.0`, and are now removed. Use direct module imports in new code.
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -21,8 +21,8 @@
             .hash = "ziggy_tool_runtime-0.1.0-t8uaSEGuAACsRd_CxS3bTmnodmeUo1SYpBDONhrphUit",
         },
         .ziggy_runtime_hooks = .{
-            .url = "https://github.com/DeanoC/ZiggyRuntimeHooks/archive/refs/tags/v0.2.1.tar.gz",
-            .hash = "ziggy_runtime_hooks-0.2.1-68kKICc9AAALrXImDGgdRh8g-c0-LKYge8XRY_dA5tvf",
+            .url = "https://github.com/DeanoC/ZiggyRuntimeHooks/archive/refs/tags/v0.3.0.tar.gz",
+            .hash = "ziggy_runtime_hooks-0.3.0-68kKICJaAAAKwDDX_TlZQGcnmkbeWm0LSIfQHD_nMx0i",
         },
     },
     .paths = .{

--- a/src/hook_registry.zig
+++ b/src/hook_registry.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const AgentRuntime = @import("agent_runtime.zig").AgentRuntime;
 const brain_tools = @import("brain_tools.zig");
 const primitives = @import("ziggy-runtime-hooks").hook_primitives;
+const engine = @import("ziggy-runtime-hooks").hook_registry_engine;
 
 pub const HookPhase = primitives.HookPhase;
 pub const HookError = primitives.HookError;
@@ -46,7 +47,6 @@ pub const HookContext = struct {
     }
 
     pub fn deinit(self: *HookContext, allocator: std.mem.Allocator) void {
-        // Free scratch values
         var scratch_it = self.scratch.iterator();
         while (scratch_it.next()) |entry| {
             allocator.free(entry.key_ptr.*);
@@ -54,23 +54,19 @@ pub const HookContext = struct {
         }
         self.scratch.deinit(allocator);
 
-        // Free trace entries
         for (self.trace.items) |entry| {
             allocator.free(entry);
         }
         self.trace.deinit(allocator);
     }
 
-    /// Set a scratch value for inter-hook communication
     pub fn setScratch(self: *HookContext, allocator: std.mem.Allocator, key: []const u8, value: []const u8) !void {
-        // Allocate new key and value first
         const owned_key = try allocator.dupe(u8, key);
         errdefer allocator.free(owned_key);
 
         const owned_value = try allocator.dupe(u8, value);
         errdefer allocator.free(owned_value);
 
-        // Check if entry exists - if so, remove and free old entry
         if (self.scratch.fetchRemove(key)) |old_entry| {
             allocator.free(old_entry.key);
             allocator.free(old_entry.value);
@@ -79,12 +75,10 @@ pub const HookContext = struct {
         try self.scratch.put(allocator, owned_key, owned_value);
     }
 
-    /// Get a scratch value
     pub fn getScratch(self: *const HookContext, key: []const u8) ?[]const u8 {
         return self.scratch.get(key);
     }
 
-    /// Add a trace entry
     pub fn tracef(self: *HookContext, allocator: std.mem.Allocator, comptime fmt: []const u8, args: anytype) !void {
         const message = try std.fmt.allocPrint(allocator, fmt, args);
         errdefer allocator.free(message);
@@ -92,183 +86,60 @@ pub const HookContext = struct {
     }
 };
 
-/// Result of Observe phase
 pub const ObserveResult = struct {
     core: *const CorePrompt,
     inbox_count: usize,
-    // TODO: Add more observe data as needed
 };
 
-/// Pending tool calls before execution
 pub const PendingTools = primitives.PendingTools;
 
-/// Results from tool execution
 pub const ToolResults = struct {
     results: []const brain_tools.ToolResult,
 };
 
-/// Results before being stored as memory artifacts
 pub const ResultsData = struct {
     tool_results: *const ToolResults,
-    // TODO: Add other result data
 };
 
-/// Checkpoint data for PostResults
 pub const CheckpointData = struct {
     tick: u64,
     artifacts_count: usize,
-    // TODO: Add more checkpoint data
 };
 
-/// Hook function signature
 pub const HookFn = *const fn (
     ctx: *HookContext,
     data: HookData,
 ) HookError!void;
 
-/// Individual hook registration
-pub const Hook = struct {
-    name: []const u8, // For debugging/logging
-    priority: i16, // Lower = earlier in pipeline
-    callback: HookFn,
-};
+pub const Hook = engine.Hook(HookContext, HookData);
+const HookRegistryEngine = engine.HookRegistry(HookContext, HookData);
 
-/// Registry for all hooks, organized by phase
+/// Adapter layer: Spiderweb-specific context/data types around shared engine.
 pub const HookRegistry = struct {
-    allocator: std.mem.Allocator,
-
-    // Sorted arrays (maintained in priority order)
-    pre_observe: std.ArrayListUnmanaged(Hook),
-    post_observe: std.ArrayListUnmanaged(Hook),
-    pre_mutate: std.ArrayListUnmanaged(Hook),
-    post_mutate: std.ArrayListUnmanaged(Hook),
-    pre_results: std.ArrayListUnmanaged(Hook),
-    post_results: std.ArrayListUnmanaged(Hook),
+    inner: HookRegistryEngine,
 
     pub fn init(allocator: std.mem.Allocator) HookRegistry {
-        return .{
-            .allocator = allocator,
-            .pre_observe = .{},
-            .post_observe = .{},
-            .pre_mutate = .{},
-            .post_mutate = .{},
-            .pre_results = .{},
-            .post_results = .{},
-        };
+        return .{ .inner = HookRegistryEngine.init(allocator) };
     }
 
     pub fn deinit(self: *HookRegistry) void {
-        self.pre_observe.deinit(self.allocator);
-        self.post_observe.deinit(self.allocator);
-        self.pre_mutate.deinit(self.allocator);
-        self.post_mutate.deinit(self.allocator);
-        self.pre_results.deinit(self.allocator);
-        self.post_results.deinit(self.allocator);
+        self.inner.deinit();
     }
 
-    /// Register a hook for a specific phase (inserted in priority order)
     pub fn register(self: *HookRegistry, phase: HookPhase, hook: Hook) !void {
-        const list = self.listForPhase(phase);
-
-        // Find insertion point (maintain sorted order by priority)
-        var insert_idx: usize = list.items.len;
-        for (list.items, 0..) |existing, i| {
-            if (hook.priority < existing.priority) {
-                insert_idx = i;
-                break;
-            }
-        }
-
-        try list.insert(self.allocator, insert_idx, hook);
+        try self.inner.register(phase, hook);
     }
 
-    /// Execute all hooks for a phase in priority order
     pub fn execute(self: *HookRegistry, phase: HookPhase, ctx: *HookContext, data: HookData) !void {
-        const list = self.listForPhase(phase);
-
-        // Update context phase before invoking callbacks
+        // Preserve existing runtime behavior: context phase is updated per execution pass.
         ctx.phase = phase;
-
-        for (list.items) |hook| {
-            hook.callback(ctx, data) catch |err| {
-                std.log.err("Hook '{s}' failed in {s}: {s}", .{ hook.name, @tagName(phase), @errorName(err) });
-                return HookError.HookFailed;
-            };
-        }
+        try self.inner.execute(phase, ctx, data);
     }
 
-    /// Get the hook list for a phase
-    fn listForPhase(self: *HookRegistry, phase: HookPhase) *std.ArrayListUnmanaged(Hook) {
-        return switch (phase) {
-            .pre_observe => &self.pre_observe,
-            .post_observe => &self.post_observe,
-            .pre_mutate => &self.pre_mutate,
-            .post_mutate => &self.post_mutate,
-            .pre_results => &self.pre_results,
-            .post_results => &self.post_results,
-        };
-    }
-
-    /// Get hook count for a phase (for debugging)
     pub fn countForPhase(self: *const HookRegistry, phase: HookPhase) usize {
-        return switch (phase) {
-            .pre_observe => self.pre_observe.items.len,
-            .post_observe => self.post_observe.items.len,
-            .pre_mutate => self.pre_mutate.items.len,
-            .post_mutate => self.post_mutate.items.len,
-            .pre_results => self.pre_results.items.len,
-            .post_results => self.post_results.items.len,
-        };
+        return self.inner.countForPhase(phase);
     }
 };
-
-// Tests
-
-test "Rom: set and get" {
-    const allocator = std.testing.allocator;
-
-    var rom = Rom.init(allocator);
-    defer rom.deinit();
-
-    try rom.set("key1", "value1");
-    try std.testing.expectEqualStrings("value1", rom.get("key1").?);
-
-    // Overwrite
-    try rom.set("key1", "value2");
-    try std.testing.expectEqualStrings("value2", rom.get("key1").?);
-
-    // Missing key
-    try std.testing.expect(rom.get("missing") == null);
-}
-
-test "HookRegistry: priority ordering" {
-    const allocator = std.testing.allocator;
-
-    var registry = HookRegistry.init(allocator);
-    defer registry.deinit();
-
-    const HookA = struct {
-        fn callback(_: *HookContext, _: HookData) HookError!void {}
-    };
-
-    const HookB = struct {
-        fn callback(_: *HookContext, _: HookData) HookError!void {}
-    };
-
-    const HookC = struct {
-        fn callback(_: *HookContext, _: HookData) HookError!void {}
-    };
-
-    // Register out of order
-    try registry.register(.pre_observe, .{ .name = "middle", .priority = 0, .callback = HookA.callback });
-    try registry.register(.pre_observe, .{ .name = "first", .priority = -100, .callback = HookB.callback });
-    try registry.register(.pre_observe, .{ .name = "last", .priority = 100, .callback = HookC.callback });
-
-    // Verify insertion order (should be sorted)
-    try std.testing.expectEqual(@as(i16, -100), registry.pre_observe.items[0].priority);
-    try std.testing.expectEqual(@as(i16, 0), registry.pre_observe.items[1].priority);
-    try std.testing.expectEqual(@as(i16, 100), registry.pre_observe.items[2].priority);
-}
 
 test "HookContext: scratch space" {
     const allocator = std.testing.allocator;
@@ -279,7 +150,98 @@ test "HookContext: scratch space" {
     try ctx.setScratch(allocator, "key1", "value1");
     try std.testing.expectEqualStrings("value1", ctx.getScratch("key1").?);
 
-    // Overwrite
     try ctx.setScratch(allocator, "key1", "value2");
     try std.testing.expectEqualStrings("value2", ctx.getScratch("key1").?);
+}
+
+test "HookRegistry adapter: priority ordering" {
+    const allocator = std.testing.allocator;
+
+    var registry = HookRegistry.init(allocator);
+    defer registry.deinit();
+
+    var core = CorePrompt.init(allocator);
+    defer core.deinit();
+
+    var ctx = HookContext.init(undefined, "test", 42);
+    defer ctx.deinit(allocator);
+
+    const State = struct {
+        var order: [8]u8 = undefined;
+        var len: usize = 0;
+    };
+    State.len = 0;
+
+    const Hooks = struct {
+        fn middle(_: *HookContext, _: HookData) HookError!void {
+            State.order[State.len] = 2;
+            State.len += 1;
+        }
+        fn first(_: *HookContext, _: HookData) HookError!void {
+            State.order[State.len] = 1;
+            State.len += 1;
+        }
+        fn last(_: *HookContext, _: HookData) HookError!void {
+            State.order[State.len] = 3;
+            State.len += 1;
+        }
+    };
+
+    try registry.register(.pre_observe, .{ .name = "middle", .priority = 0, .callback = Hooks.middle });
+    try registry.register(.pre_observe, .{ .name = "first", .priority = -100, .callback = Hooks.first });
+    try registry.register(.pre_observe, .{ .name = "last", .priority = 100, .callback = Hooks.last });
+
+    try registry.execute(.pre_observe, &ctx, .{ .pre_observe = &core });
+
+    try std.testing.expectEqual(HookPhase.pre_observe, ctx.phase);
+    try std.testing.expectEqual(@as(usize, 3), State.len);
+    try std.testing.expectEqual(@as(u8, 1), State.order[0]);
+    try std.testing.expectEqual(@as(u8, 2), State.order[1]);
+    try std.testing.expectEqual(@as(u8, 3), State.order[2]);
+}
+
+test "HookRegistry adapter: failure propagation and stop-on-error" {
+    const allocator = std.testing.allocator;
+
+    var registry = HookRegistry.init(allocator);
+    defer registry.deinit();
+
+    var core = CorePrompt.init(allocator);
+    defer core.deinit();
+
+    var ctx = HookContext.init(undefined, "test", 99);
+    defer ctx.deinit(allocator);
+
+    const State = struct {
+        var order: [8]u8 = undefined;
+        var len: usize = 0;
+    };
+    State.len = 0;
+
+    const Hooks = struct {
+        fn first(_: *HookContext, _: HookData) HookError!void {
+            State.order[State.len] = 1;
+            State.len += 1;
+        }
+        fn fail(_: *HookContext, _: HookData) HookError!void {
+            State.order[State.len] = 2;
+            State.len += 1;
+            return HookError.HookFailed;
+        }
+        fn should_not_run(_: *HookContext, _: HookData) HookError!void {
+            State.order[State.len] = 3;
+            State.len += 1;
+        }
+    };
+
+    try registry.register(.pre_observe, .{ .name = "first", .priority = -100, .callback = Hooks.first });
+    try registry.register(.pre_observe, .{ .name = "fail", .priority = 0, .callback = Hooks.fail });
+    try registry.register(.pre_observe, .{ .name = "later", .priority = 100, .callback = Hooks.should_not_run });
+
+    try std.testing.expectError(HookError.HookFailed, registry.execute(.pre_observe, &ctx, .{ .pre_observe = &core }));
+
+    try std.testing.expectEqual(HookPhase.pre_observe, ctx.phase);
+    try std.testing.expectEqual(@as(usize, 2), State.len);
+    try std.testing.expectEqual(@as(u8, 1), State.order[0]);
+    try std.testing.expectEqual(@as(u8, 2), State.order[1]);
 }


### PR DESCRIPTION
## Summary\n- pin ziggy_runtime_hooks to v0.3.0\n- delegate HookRegistry execution/order mechanics to shared hook_registry_engine\n- keep Spiderweb-specific HookContext/HookData adapter layer\n- add integration tests for adapter ordering and failure propagation\n\n## Validation\n- zig build\n- zig build test\n