### PR TITLE
Wave-3: orchestration helpers + shared CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,33 +8,15 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Verify pinned Ziggy module dependencies
-        run: |
-          if grep -qE '\\.path = "\\.\\./Ziggy' build.zig.zon; then
-            echo "Local path Ziggy dependencies are not allowed in CI"
-            exit 1
-          fi
-          grep -q 'ziggy_spider_protocol' build.zig.zon
-          grep -q 'ziggy_memory_store' build.zig.zon
-          grep -q 'ziggy_tool_runtime' build.zig.zon
-          grep -q 'ziggy_runtime_hooks' build.zig.zon
-          grep -q '\.hash =' build.zig.zon
-
-      - name: Install Zig
-        run: |
-          ZIG_VERSION=0.15.1
-          curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" -o zig.tar.xz
-          tar -xf zig.tar.xz
-          export PATH="$PWD/zig-x86_64-linux-${ZIG_VERSION}:$PATH"
-          echo "$PWD/zig-x86_64-linux-${ZIG_VERSION}" >> "$GITHUB_PATH"
-          zig version
-
-      - name: Build
-        run: zig build
-
-      - name: Test
-        run: zig build test
+    uses: ./.github/workflows/ziggy-shared-ci.yml
+    with:
+      verify_script: |
+        if grep -qE '\.path = "\.\./Ziggy' build.zig.zon; then
+          echo "Local path Ziggy dependencies are not allowed in CI"
+          exit 1
+        fi
+        grep -q 'ziggy_spider_protocol' build.zig.zon
+        grep -q 'ziggy_memory_store' build.zig.zon
+        grep -q 'ziggy_tool_runtime' build.zig.zon
+        grep -q 'ziggy_runtime_hooks' build.zig.zon
+        grep -q '\.hash =' build.zig.zon

--- a/.github/workflows/ziggy-shared-ci.yml
+++ b/.github/workflows/ziggy-shared-ci.yml
@@ -1,0 +1,79 @@
+name: ziggy-shared-ci
+
+on:
+  workflow_call:
+    inputs:
+      verify_script:
+        required: false
+        type: string
+        default: ""
+      install_sqlite:
+        required: false
+        type: boolean
+        default: false
+      zig_version:
+        required: false
+        type: string
+        default: "0.15.1"
+      build_command:
+        required: false
+        type: string
+        default: "zig build"
+      test_command:
+        required: false
+        type: string
+        default: "zig build test"
+      extra_commands:
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify repository checks
+        if: ${{ inputs.verify_script != '' }}
+        env:
+          VERIFY_SCRIPT: ${{ inputs.verify_script }}
+        run: |
+          printf '%s\n' "$VERIFY_SCRIPT" > /tmp/ziggy-ci-verify.sh
+          bash /tmp/ziggy-ci-verify.sh
+
+      - name: Install SQLite development package
+        if: ${{ inputs.install_sqlite }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsqlite3-dev
+
+      - name: Install Zig
+        env:
+          ZIG_VERSION: ${{ inputs.zig_version }}
+        run: |
+          curl -fsSL "https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz" -o zig.tar.xz
+          tar -xf zig.tar.xz
+          export PATH="$PWD/zig-x86_64-linux-${ZIG_VERSION}:$PATH"
+          echo "$PWD/zig-x86_64-linux-${ZIG_VERSION}" >> "$GITHUB_PATH"
+          zig version
+
+      - name: Build
+        env:
+          BUILD_COMMAND: ${{ inputs.build_command }}
+        run: |
+          bash -lc "$BUILD_COMMAND"
+
+      - name: Test
+        env:
+          TEST_COMMAND: ${{ inputs.test_command }}
+        run: |
+          bash -lc "$TEST_COMMAND"
+
+      - name: Extra commands
+        if: ${{ inputs.extra_commands != '' }}
+        env:
+          EXTRA_COMMANDS: ${{ inputs.extra_commands }}
+        run: |
+          printf '%s\n' "$EXTRA_COMMANDS" > /tmp/ziggy-ci-extra.sh
+          bash /tmp/ziggy-ci-extra.sh

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -21,8 +21,8 @@
             .hash = "ziggy_tool_runtime-0.1.0-t8uaSEGuAACsRd_CxS3bTmnodmeUo1SYpBDONhrphUit",
         },
         .ziggy_runtime_hooks = .{
-            .url = "https://github.com/DeanoC/ZiggyRuntimeHooks/archive/refs/tags/v0.4.0.tar.gz",
-            .hash = "ziggy_runtime_hooks-0.4.0-68kKIL4JAQBsawvRXD_LuuBL6DmJ2BQ8Vel6eUn0Ol5L",
+            .url = "https://github.com/DeanoC/ZiggyRuntimeHooks/archive/a928d762d2ef3fe67b08b7bc2eba5b30b86c2c08.tar.gz",
+            .hash = "ziggy_runtime_hooks-0.4.0-68kKIGUfAQAdnk_5_IAhBq0vkOxAZjbzBphuUMCbAqfp",
         },
     },
     .paths = .{


### PR DESCRIPTION
## Summary
- consume `run_orchestration_helpers` from `ziggy-runtime-hooks` for:
  - run-step cancellation tracking
  - operation timeout policy helpers
- pin `ziggy_runtime_hooks` to commit `a928d762d2ef3fe67b08b7bc2eba5b30b86c2c08` (no release tag)
- add reusable workflow `.github/workflows/ziggy-shared-ci.yml`
- move Spiderweb CI to call the reusable workflow

## Validation
- zig build
- zig build test
