### PR TITLE
fix: prevent stale codex model selection

### DIFF
--- a/src/config_cli.zig
+++ b/src/config_cli.zig
@@ -5,6 +5,7 @@ const credential_store = @import("credential_store.zig");
 const ziggy_piai = @import("ziggy-piai");
 const first_run = @import("first_run.zig");
 const oauth_cli = @import("oauth_cli.zig");
+const provider_models = @import("provider_models.zig");
 
 const auth_tokens_filename = "auth_tokens.json";
 
@@ -135,7 +136,11 @@ fn handleConfigCommand(allocator: std.mem.Allocator, args: []const []const u8) !
         defer config.deinit();
 
         const provider = args[1];
-        const model = if (args.len >= 3) args[2] else null;
+        const requested_model = if (args.len >= 3) args[2] else provider_models.preferredDefaultModel(provider);
+        const model = if (requested_model) |value|
+            provider_models.remapLegacyModel(provider, value) orelse value
+        else
+            null;
 
         try config.setProvider(provider, model);
         std.log.info("Set provider to {s} (model: {s})", .{ provider, model orelse "default" });

--- a/src/first_run.zig
+++ b/src/first_run.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const Config = @import("config.zig");
 const credential_store = @import("credential_store.zig");
+const provider_models = @import("provider_models.zig");
 const ziggy_piai = @import("ziggy-piai");
 const max_agent_id_len: usize = 64;
 
@@ -49,7 +50,7 @@ pub fn runFirstRun(allocator: std.mem.Allocator, args: []const []const u8) !void
     try std.fs.File.stdout().writeAll("\n");
 
     // Step 1: Provider selection
-    const provider_name, const model_name = if (non_interactive) blk: {
+    const provider_name, const selected_model_name = if (non_interactive) blk: {
         const p = provider_param orelse {
             std.log.err("--provider required in non-interactive mode", .{});
             return error.InvalidArguments;
@@ -58,6 +59,16 @@ pub fn runFirstRun(allocator: std.mem.Allocator, args: []const []const u8) !void
     } else blk: {
         break :blk try selectProviderInteractive(allocator);
     };
+
+    var model_name = selected_model_name;
+    if (model_name) |value| {
+        if (provider_models.remapLegacyModel(provider_name, value)) |mapped| {
+            std.log.warn("Model {s}/{s} is deprecated; using {s}", .{ provider_name, value, mapped });
+            model_name = mapped;
+        }
+    } else {
+        model_name = provider_models.preferredDefaultModel(provider_name);
+    }
 
     // Step 2: Configure credentials
     try configureCredentials(allocator, provider_name, non_interactive);
@@ -169,7 +180,7 @@ fn selectProviderInteractive(allocator: std.mem.Allocator) !struct { []const u8,
     try std.fs.File.stdout().writeAll("\nSelect your AI provider:\n\n");
     try std.fs.File.stdout().writeAll("Quick setup:\n");
     try std.fs.File.stdout().writeAll("  1) OpenAI        - GPT-4o, GPT-4.1\n");
-    try std.fs.File.stdout().writeAll("  2) OpenAI Codex  - GPT-5.1, GPT-5.2, GPT-5.3 (with OAuth support)\n");
+    try std.fs.File.stdout().writeAll("  2) OpenAI Codex  - GPT-5.3 Codex (with OAuth support)\n");
     try std.fs.File.stdout().writeAll("  3) Kimi Coding   - Kimi K2, K2.5 (Moonshot AI)\n");
     try std.fs.File.stdout().writeAll("\n  4) Manual setup  - Other providers\n");
 
@@ -188,7 +199,7 @@ fn selectProviderInteractive(allocator: std.mem.Allocator) !struct { []const u8,
         if (std.mem.eql(u8, choice, "1")) {
             return .{ "openai", try selectModel(allocator, &.{ "gpt-4o-mini", "gpt-4.1-mini" }) };
         } else if (std.mem.eql(u8, choice, "2")) {
-            return .{ "openai-codex", try selectModel(allocator, &.{ "gpt-5.1-codex-mini", "gpt-5.1", "gpt-5.3-codex", "gpt-5.3-codex-spark" }) };
+            return .{ "openai-codex", try selectModel(allocator, &.{ "gpt-5.3-codex", "gpt-5.3-codex-spark", "gpt-5.2-codex", "gpt-5.1-codex-mini" }) };
         } else if (std.mem.eql(u8, choice, "3")) {
             return .{ "kimi-coding", try selectModel(allocator, &.{ "k2p5", "kimi-k2.5" }) };
         } else if (std.mem.eql(u8, choice, "4")) {

--- a/src/provider_models.zig
+++ b/src/provider_models.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+
+pub fn preferredDefaultModel(provider_name: []const u8) ?[]const u8 {
+    if (std.mem.eql(u8, provider_name, "openai-codex")) return "gpt-5.3-codex";
+    if (std.mem.eql(u8, provider_name, "openai-codex-spark")) return "chatgpt5.3-spark";
+    return null;
+}
+
+pub fn remapLegacyModel(provider_name: []const u8, model_name: []const u8) ?[]const u8 {
+    if (std.mem.eql(u8, provider_name, "openai-codex")) {
+        if (std.mem.eql(u8, model_name, "gpt-5.1")) return "gpt-5.3-codex";
+        if (std.mem.eql(u8, model_name, "gpt-5.1-codex")) return "gpt-5.3-codex";
+    }
+
+    if (std.mem.eql(u8, provider_name, "openai-codex-spark")) {
+        if (std.mem.eql(u8, model_name, "gpt-5.1")) return "chatgpt5.3-spark";
+    }
+
+    return null;
+}
+
+test "provider_models: preferred defaults are provider-specific" {
+    try std.testing.expectEqualStrings("gpt-5.3-codex", preferredDefaultModel("openai-codex").?);
+    try std.testing.expectEqualStrings("chatgpt5.3-spark", preferredDefaultModel("openai-codex-spark").?);
+    try std.testing.expect(preferredDefaultModel("openai") == null);
+}
+
+test "provider_models: remap legacy codex model ids" {
+    try std.testing.expectEqualStrings("gpt-5.3-codex", remapLegacyModel("openai-codex", "gpt-5.1").?);
+    try std.testing.expectEqualStrings("gpt-5.3-codex", remapLegacyModel("openai-codex", "gpt-5.1-codex").?);
+    try std.testing.expect(remapLegacyModel("openai-codex", "gpt-5.3-codex") == null);
+    try std.testing.expect(remapLegacyModel("openai", "gpt-5.1") == null);
+}


### PR DESCRIPTION
## Summary\n- enforce provider-specific preferred model defaults for codex providers\n- remap legacy codex model ids (including gpt-5.1) to supported defaults\n- harden runtime model fallback to recover from model-not-found style provider errors\n- keep oauth/config/first-run model selection aligned with current defaults\n- fix Config.setProvider ownership/clearing behavior and add regression tests\n\n## Validation\n- zig build\n- zig build test