### PR TITLE
reset: remove user systemd service drop-in directory

### DIFF
--- a/scripts/full-reset.sh
+++ b/scripts/full-reset.sh
@@ -22,6 +22,7 @@ fi
 
 USER_PATHS=(
     "$TARGET_HOME/.config/systemd/user/spiderweb.service"
+    "$TARGET_HOME/.config/systemd/user/spiderweb.service.d"
     "$TARGET_HOME/.config/systemd/user/default.target.wants/spiderweb.service"
     "$TARGET_HOME/.config/spiderweb"
     "$TARGET_HOME/.cache/ziggy-spiderweb"


### PR DESCRIPTION
## Summary\n- include ~/.config/systemd/user/spiderweb.service.d in full-reset cleanup targets\n\n## Why\n- stale user drop-in overrides can survive reset and affect fresh install startup behavior\n\n## Test\n- bash -n scripts/full-reset.sh\n