### PR TITLE
fix: restrict terminal-v2 invocation for non-admin user actor sessions

### DIFF
--- a/src/acheron/session.zig
+++ b/src/acheron/session.zig
@@ -918,6 +918,14 @@ pub const Session = struct {
         defer if (job_name) |value| self.allocator.free(value);
         defer if (correlation_id) |value| self.allocator.free(value);
         defer if (chat_reply_content) |value| self.allocator.free(value);
+        if (isTerminalV2Special(node.special) and !self.canInvokeTerminalNamespace(state.node_id)) {
+            return unified.buildFsrpcError(
+                self.allocator,
+                msg.tag,
+                "eperm",
+                "terminal invoke access denied by permissions",
+            );
+        }
         if (try self.tryWriteBoundVenomProxyFile(state.node_id, offset, data)) |proxied| {
             written = proxied.written;
             job_name = proxied.job_name;
@@ -4940,6 +4948,30 @@ pub const Session = struct {
             return self.canAccessVenomWithPermissions("");
         };
         return self.canAccessVenomWithPermissions(permissions_node.content);
+    }
+
+    fn canInvokeTerminalNamespace(self: *Session, terminal_node_id: u32) bool {
+        const terminal_node = self.nodes.get(terminal_node_id) orelse return false;
+        const control_dir_id = terminal_node.parent orelse return false;
+        const venom_dir_id = (self.nodes.get(control_dir_id) orelse return false).parent orelse return false;
+        if (!self.canInvokeVenomDirectory(venom_dir_id)) return false;
+        if (!self.is_admin and std.mem.eql(u8, self.actor_type, "user")) return false;
+        return true;
+    }
+
+    fn isTerminalV2Special(special: SpecialKind) bool {
+        return switch (special) {
+            .terminal_v2_invoke,
+            .terminal_v2_create,
+            .terminal_v2_resume,
+            .terminal_v2_close,
+            .terminal_v2_exec,
+            .terminal_v2_write,
+            .terminal_v2_read,
+            .terminal_v2_resize,
+            => true,
+            else => false,
+        };
     }
 
     fn appendVenomIndexEntry(
@@ -12880,6 +12912,40 @@ test "acheron_session: first-class terminal namespace operation file maps to run
     );
     defer allocator.free(result_payload);
     try std.testing.expect(std.mem.indexOf(u8, result_payload, "terminal-namespace") != null);
+}
+
+test "acheron_session: first-class terminal namespace denies user actor shell access" {
+    const allocator = std.testing.allocator;
+
+    const runtime_server = try runtime_server_mod.RuntimeServer.create(allocator, "default", .{});
+    const runtime_handle = try runtime_handle_mod.RuntimeHandle.createLocal(allocator, runtime_server);
+    defer runtime_handle.destroy();
+    var job_index = chat_job_index.ChatJobIndex.init(allocator, "");
+    defer job_index.deinit();
+
+    var session = try Session.initWithOptions(
+        allocator,
+        runtime_handle,
+        &job_index,
+        "default",
+        .{
+            .actor_type = "user",
+        },
+    );
+    defer session.deinit();
+
+    const response = try protocolWriteFileExpectError(
+        &session,
+        allocator,
+        240,
+        241,
+        &.{ "agents", "self", "terminal", "control", "exec.json" },
+        "{\"command\":\"echo terminal-namespace\"}",
+        909,
+        "eperm",
+    );
+    defer allocator.free(response);
+    try std.testing.expect(std.mem.indexOf(u8, response, "terminal invoke access denied by permissions") != null);
 }
 
 test "acheron_session: terminal-v2 session lifecycle updates current and sessions state" {


### PR DESCRIPTION
### Motivation

- The repository added a first-class terminal namespace that bridges to the runtime `shell_exec` tool and had permissive `PERMISSIONS.json` allowing `user` role to invoke it, which exposed an RCE path for any authenticated user with invoke rights.

### Description

- Added a fast-fail authorization gate in `handleWrite` to deny writes to terminal-v2 control files when terminal invocation is not permitted, returning an `eperm` error and message `terminal invoke access denied by permissions`.
- Introduced `canInvokeTerminalNamespace` to centralize terminal-specific invocation policy that combines existing service permission checks with an additional rule that denies terminal-v2 invocation for non-admin sessions whose `actor_type` is `user`.
- Added `isTerminalV2Special` helper to identify terminal-v2 special files so the check applies consistently to all terminal control endpoints.
- Added a regression test `fsrpc_session: first-class terminal namespace denies user actor shell access` that asserts a `user` actor receives `eperm` when writing to `/agents/self/terminal/control/exec.json`.
- Modified file: `src/fsrpc_session.zig`.

### Testing

- Added an automated unit test covering the denial path: `test "fsrpc_session: first-class terminal namespace denies user actor shell access"` (present in `src/fsrpc_session.zig`) but it could not be executed in this environment.
- Attempted to run formatting and test commands: `zig fmt src/fsrpc_session.zig`, `zig build`, and `zig build test`, each failed because the `zig` tool is not installed in the current environment, so no test execution results are available.
- Static inspection and targeted searches were used to validate the change touches the terminal-v2 write/invoke surfaces and the permission enforcement site before landing the patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac11dc9724832396dd802071fb4e12)