### PR TITLE
fix: prefer /global service paths for unbound services to avoid local-catalog bypass

### DIFF
--- a/src/acheron/session.zig
+++ b/src/acheron/session.zig
@@ -5252,14 +5252,6 @@ pub const Session = struct {
         }
 
         self.allocator.free(workspace_path);
-        const catalog_path = if (suffix.len == 0)
-            try std.fmt.allocPrint(self.allocator, "/nodes/local/venoms/{s}", .{service_id})
-        else
-            try std.fmt.allocPrint(self.allocator, "/nodes/local/venoms/{s}{s}", .{ service_id, suffix });
-        errdefer self.allocator.free(catalog_path);
-        if (self.resolveAbsolutePathNoBinds(catalog_path) != null) return catalog_path;
-
-        self.allocator.free(catalog_path);
         return if (suffix.len == 0)
             try std.fmt.allocPrint(self.allocator, "/global/{s}", .{service_id})
         else
@@ -17942,7 +17934,7 @@ test "acheron_session: preferred service paths use workspace bindings when avail
 
     const unbound_github_path = try unbound_session.resolvePreferredServicePath("github_pr", "/control/sync.json");
     defer allocator.free(unbound_github_path);
-    try std.testing.expectEqualStrings("/nodes/local/venoms/github_pr/control/sync.json", unbound_github_path);
+    try std.testing.expectEqualStrings("/global/github_pr/control/sync.json", unbound_github_path);
 }
 
 test "acheron_session: bound workspace service paths are readable through /services" {


### PR DESCRIPTION
### Motivation

- A seeding change made `/nodes/local/venoms/*` always present and `resolvePreferredServicePath` preferred those local paths, allowing PR/GitHub workflows to invoke host-local services and bypass operator-configured bound providers.
- The intent is to restore routing semantics so unbound service resolution does not inadvertently pick local catalog paths that evade the bound-provider proxy.

### Description

- Removed the `/nodes/local/venoms/...` fallback from `Session.resolvePreferredServicePath` so unbound resolution now falls back directly to `/global/...` (file: `src/acheron/session.zig`).
- Updated the existing preferred-path unit test expectation to assert `/global/github_pr/control/sync.json` for unbound sessions (file: `src/acheron/session.zig`).
- This is a minimal behavioral change that preserves workspace `/services/...` bindings while preventing automatic selection of local catalog venoms for unbound services.

### Testing

- Attempted to run `zig fmt src/acheron/session.zig`, but the command failed because `zig` is not installed in the execution environment.
- Attempted to run `zig build` and `zig build test`, but both failed for the same reason (`zig` not installed), so automated test execution could not be completed here.
- Code-level validation performed via local static inspection and adjustments to the unit-test expectation were committed to ensure the codebase reflects the secured behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b037c707dc8323bb96aaec993d9840)