### PR TITLE
Fix mounted workspace service projection and readdir pagination

### DIFF
--- a/src/acheron/control_plane.zig
+++ b/src/acheron/control_plane.zig
@@ -15,7 +15,7 @@ const spider_web_project_status = "active";
 const spider_web_project_vision = "System project for Spiderweb control and host integrations";
 const spider_web_workspace_mount_path = "/nodes/local/fs";
 const spider_web_project_mount_prefix = "/nodes/local/projects/" ++ spider_web_project_id ++ "/";
-const default_project_up_export_name = "work";
+const default_project_up_export_name = "system-workspace";
 const spider_web_project_kind_name = "system_builtin";
 const normal_project_kind_name = "normal";
 const system_project_template_id = "system";
@@ -310,6 +310,9 @@ const minimum_template_bind_specs = [_]ProjectTemplateBindSpec{
     .{ .bind_path = "/services/mounts", .venom_id = "mounts" },
     .{ .bind_path = "/services/home", .venom_id = "home" },
     .{ .bind_path = "/services/workers", .venom_id = "workers" },
+    .{ .bind_path = "/services/chat", .venom_id = "chat", .provider_scope = "session_dynamic" },
+    .{ .bind_path = "/services/jobs", .venom_id = "jobs", .provider_scope = "session_dynamic" },
+    .{ .bind_path = "/services/events", .venom_id = "events" },
 };
 
 const system_template_bind_specs = [_]ProjectTemplateBindSpec{
@@ -317,6 +320,9 @@ const system_template_bind_specs = [_]ProjectTemplateBindSpec{
     .{ .bind_path = "/services/mounts", .venom_id = "mounts" },
     .{ .bind_path = "/services/home", .venom_id = "home" },
     .{ .bind_path = "/services/workers", .venom_id = "workers" },
+    .{ .bind_path = "/services/chat", .venom_id = "chat", .provider_scope = "session_dynamic" },
+    .{ .bind_path = "/services/jobs", .venom_id = "jobs", .provider_scope = "session_dynamic" },
+    .{ .bind_path = "/services/events", .venom_id = "events" },
 };
 
 const github_template_bind_specs = [_]ProjectTemplateBindSpec{
@@ -324,6 +330,8 @@ const github_template_bind_specs = [_]ProjectTemplateBindSpec{
     .{ .bind_path = "/services/mounts", .venom_id = "mounts" },
     .{ .bind_path = "/services/home", .venom_id = "home" },
     .{ .bind_path = "/services/workers", .venom_id = "workers" },
+    .{ .bind_path = "/services/chat", .venom_id = "chat", .provider_scope = "session_dynamic" },
+    .{ .bind_path = "/services/jobs", .venom_id = "jobs", .provider_scope = "session_dynamic" },
     .{ .bind_path = "/services/git", .venom_id = "git" },
     .{ .bind_path = "/services/github_pr", .venom_id = "github_pr" },
     .{ .bind_path = "/services/missions", .venom_id = "missions" },
@@ -3282,7 +3290,7 @@ pub const ControlPlane = struct {
             project,
             now_ms,
             null,
-            self.isPrimaryAgent(agent_id),
+            self.isPrimaryAgent(agent_id) or is_admin,
             agent_id,
             project_token,
             is_admin,
@@ -7411,6 +7419,10 @@ test "acheron_control_plane: workspaceStatus supports explicit project selection
     const selected_primary = try plane.workspaceStatus(default_primary_agent_id, selected_req);
     defer allocator.free(selected_primary);
     try std.testing.expect(std.mem.indexOf(u8, selected_primary, "\"fs_auth_token\":\"") != null);
+
+    const selected_admin = try plane.workspaceStatusWithRole("agent-selector", selected_req, true);
+    defer allocator.free(selected_admin);
+    try std.testing.expect(std.mem.indexOf(u8, selected_admin, "\"fs_auth_token\":\"") != null);
 
     const selected_without_token = try std.fmt.allocPrint(
         allocator,

--- a/src/acheron/namespace_client.zig
+++ b/src/acheron/namespace_client.zig
@@ -415,10 +415,11 @@ pub const NamespaceClient = struct {
             .file => 1,
             .dir => 2,
         };
+        const owner = currentProcessAttrOwner();
         return std.fmt.allocPrint(
             self.allocator,
-            "{{\"id\":{d},\"k\":{d},\"m\":{d},\"n\":{d},\"u\":0,\"g\":0,\"sz\":{d},\"at\":0,\"mt\":0,\"ct\":0,\"gen\":0}}",
-            .{ stat.id, kind_code, normalizeMode(stat.mode, stat.kind), nlink, stat.size },
+            "{{\"id\":{d},\"k\":{d},\"m\":{d},\"n\":{d},\"u\":{d},\"g\":{d},\"sz\":{d},\"at\":0,\"mt\":0,\"ct\":0,\"gen\":0}}",
+            .{ stat.id, kind_code, normalizeMode(stat.mode, stat.kind), nlink, owner.uid, owner.gid, stat.size },
         );
     }
 
@@ -1098,6 +1099,13 @@ fn normalizeMode(mode: u32, kind: NamespaceStat.Kind) u32 {
     };
 }
 
+fn currentProcessAttrOwner() struct { uid: u32, gid: u32 } {
+    return switch (builtin.os.tag) {
+        .linux => .{ .uid = @intCast(std.os.linux.getuid()), .gid = @intCast(std.os.linux.getgid()) },
+        else => .{ .uid = 0, .gid = 0 },
+    };
+}
+
 fn flagsRequireWrite(flags: u32) bool {
     return (flags & 0x3) != 0;
 }
@@ -1243,6 +1251,27 @@ test "namespace_client: stat attrs synthesize mode from kind when remote mode is
     try std.testing.expectEqual(@as(u64, 4), stat.id);
     try std.testing.expectEqual(NamespaceStat.Kind.dir, stat.kind);
     try std.testing.expectEqual(@as(u32, 0o040755), normalizeMode(stat.mode, stat.kind));
+}
+
+test "namespace_client: stat attrs use current process owner on posix" {
+    if (builtin.os.tag != .linux) return;
+
+    var client: NamespaceClient = undefined;
+    client.allocator = std.testing.allocator;
+    const attr_json = try client.statToAttrJson(.{
+        .id = 7,
+        .kind = .file,
+        .size = 11,
+        .mode = 0o100644,
+        .writable = true,
+    });
+    defer std.testing.allocator.free(attr_json);
+
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, attr_json, .{});
+    defer parsed.deinit();
+
+    try std.testing.expectEqual(@as(i64, std.os.linux.getuid()), parsed.value.object.get("u").?.integer);
+    try std.testing.expectEqual(@as(i64, std.os.linux.getgid()), parsed.value.object.get("g").?.integer);
 }
 
 test "namespace_client: parseReadPayload decodes data_b64" {

--- a/src/acheron/router.zig
+++ b/src/acheron/router.zig
@@ -1549,11 +1549,7 @@ pub const Router = struct {
         var parsed = try std.json.parseFromSlice(std.json.Value, self.allocator, payload_json, .{});
         defer parsed.deinit();
         if (parsed.value != .object) return .{ .complete = false, .next_cookie = 0 };
-        const next_cookie = parsed.value.object.get("next_cookie");
-        const parsed_next_cookie: u64 = if (next_cookie) |value|
-            (if (value == .integer and value.integer >= 0) @as(u64, @intCast(value.integer)) else 0)
-        else
-            0;
+        const parsed_next_cookie = parseReaddirNextCookie(parsed.value.object);
         const complete = parsed_next_cookie == 0;
         const ents = parsed.value.object.get("ents") orelse return .{ .complete = complete, .next_cookie = parsed_next_cookie };
         if (ents != .array) return .{ .complete = complete, .next_cookie = parsed_next_cookie };
@@ -1578,6 +1574,16 @@ pub const Router = struct {
             try self.dir_cache.put(endpoint_index, dir_id, normalized_name, node_id, attr_json, now);
         }
         return .{ .complete = complete, .next_cookie = parsed_next_cookie };
+    }
+
+    fn parseReaddirNextCookie(obj: std.json.ObjectMap) u64 {
+        if (obj.get("next_cookie")) |value| {
+            if (value == .integer and value.integer >= 0) return @intCast(value.integer);
+        }
+        if (obj.get("next")) |value| {
+            if (value == .integer and value.integer >= 0) return @intCast(value.integer);
+        }
+        return 0;
     }
 
     fn isVirtualDirectoryPath(self: *const Router, path: []const u8) bool {
@@ -2781,4 +2787,10 @@ test "acheron_router: replaceEndpoints swaps mount topology and clears caches" {
     try std.testing.expect(router.dir_listing_cache.getFresh(.{ .endpoint_index = 0, .node_id = 10 }, now) == null);
     try std.testing.expect(!router.dir_complete_cache.isFresh(.{ .endpoint_index = 0, .node_id = 10 }, now));
     try std.testing.expect(!router.dir_prime_cache.isFresh(.{ .endpoint_index = 0, .node_id = 10 }, now));
+}
+
+test "acheron_router: parseReaddirNextCookie accepts next" {
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, "{\"ents\":[],\"next\":18}", .{});
+    defer parsed.deinit();
+    try std.testing.expectEqual(@as(u64, 18), Router.parseReaddirNextCookie(parsed.value.object));
 }

--- a/src/acheron/session.zig
+++ b/src/acheron/session.zig
@@ -6328,10 +6328,7 @@ pub const Session = struct {
         defer parsed.deinit();
         if (parsed.value != .object) return 0;
 
-        const next_cookie: u64 = if (parsed.value.object.get("next_cookie")) |value|
-            if (value == .integer and value.integer >= 0) @intCast(value.integer) else 0
-        else
-            0;
+        const next_cookie = parseReaddirNextCookie(parsed.value.object);
         const ents = parsed.value.object.get("ents") orelse return next_cookie;
         if (ents != .array) return next_cookie;
         for (ents.array.items) |entry| {
@@ -6342,6 +6339,16 @@ pub const Session = struct {
             try self.upsertBoundVenomProxyChild(parent_id, name_val.string, attr_val);
         }
         return next_cookie;
+    }
+
+    fn parseReaddirNextCookie(obj: std.json.ObjectMap) u64 {
+        if (obj.get("next_cookie")) |value| {
+            if (value == .integer and value.integer >= 0) return @intCast(value.integer);
+        }
+        if (obj.get("next")) |value| {
+            if (value == .integer and value.integer >= 0) return @intCast(value.integer);
+        }
+        return 0;
     }
 
     fn upsertBoundVenomProxyChild(self: *Session, parent_id: u32, name: []const u8, attr_val: std.json.Value) !void {
@@ -9412,4 +9419,10 @@ fn decodeReadResponseData(allocator: std.mem.Allocator, frame: []const u8) ![]u8
     errdefer allocator.free(decoded);
     try std.base64.standard.Decoder.decode(decoded, data_b64.string);
     return decoded;
+}
+
+test "session: parseReaddirNextCookie accepts next" {
+    var parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, "{\"ents\":[],\"next\":18}", .{});
+    defer parsed.deinit();
+    try std.testing.expectEqual(@as(u64, 18), Session.parseReaddirNextCookie(parsed.value.object));
 }

--- a/src/venoms/fs/fs_fuse_adapter.zig
+++ b/src/venoms/fs/fs_fuse_adapter.zig
@@ -297,7 +297,7 @@ pub const FuseAdapter = struct {
         } else |_| {}
         const mount_options = switch (@import("builtin").os.tag) {
             .windows => "uid=-1,gid=-1,FileInfoTimeout=-1",
-            else => "default_permissions,attr_timeout=120,entry_timeout=120,negative_timeout=10",
+            else => "default_permissions,attr_timeout=1,entry_timeout=1,negative_timeout=0",
         };
         try appendArgZ(self.allocator, &argv, "-o");
         try appendArgZ(self.allocator, &argv, mount_options);
@@ -601,6 +601,7 @@ fn cOpen(path_c: [*c]const u8, fi: ?*c.struct_fuse_file_info) callconv(.c) c_int
     if (path_c == null) return -fs_protocol.Errno.EINVAL;
     const path = std.mem.span(path_c);
     const flags = if (fi) |info| @as(u32, @intCast(c.spiderweb_fi_get_flags(info))) else @as(u32, 0);
+    fuseTrace("open path={s} flags={d}", .{ path, flags });
     if (fi) |info| {
         const local_id = adapter.openAndStoreHandle(path, flags) catch |err| return toFuseError(err);
         c.spiderweb_fi_set_fh(info, local_id);
@@ -616,6 +617,7 @@ fn cRead(path_c: [*c]const u8, buf: [*c]u8, size: usize, off: c.off_t, fi: ?*c.s
     if (path_c == null) return -fs_protocol.Errno.EINVAL;
     if (off < 0) return -fs_protocol.Errno.EINVAL;
     const path = std.mem.span(path_c);
+    fuseTrace("read path={s} size={d} off={d}", .{ path, size, off });
 
     var open_file: mount_provider.OpenFile = undefined;
     var owns_close = false;
@@ -758,8 +760,9 @@ fn cWriteWin(path_c: [*c]const u8, buf: [*c]const u8, size: usize, off: c.fuse_o
 }
 
 fn cRelease(path_c: [*c]const u8, fi: ?*c.struct_fuse_file_info) callconv(.c) c_int {
-    _ = path_c;
+    const path = if (path_c) |value| std.mem.span(value) else "";
     const adapter = active_adapter orelse return -fs_protocol.Errno.EIO;
+    fuseTrace("release path={s}", .{path});
     if (fi) |info| {
         const local_id = c.spiderweb_fi_get_fh(info);
         if (local_id != 0) {

--- a/src/venoms/home.zig
+++ b/src/venoms/home.zig
@@ -81,7 +81,7 @@ pub fn seedNamespaceAt(self: anytype, home_dir: u32, base_path: []const u8) !voi
     _ = try self.addFile(
         control_dir,
         "README.md",
-        "Write {\"agent_id\":\"...\"} to ensure.json to provision /agents/<agent_id>/home as a durable bind into the mounted workspace.\n",
+        "Write {\"agent_id\":\"...\"} to ensure.json to provision /home/<agent_id> as a durable bind into the mounted workspace.\n",
         false,
         .none,
     );
@@ -174,7 +174,7 @@ fn executeOpPayload(self: anytype, op: Op, args_obj: std.json.ObjectMap) ![]u8 {
         const trimmed = std.mem.trim(u8, value, " \t\r\n");
         if (trimmed.len == 0) return error.InvalidPayload;
         break :blk try self.allocator.dupe(u8, trimmed);
-    } else try std.fmt.allocPrint(self.allocator, "/agents/{s}/home", .{agent_id});
+    } else try std.fmt.allocPrint(self.allocator, "/home/{s}", .{agent_id});
     defer self.allocator.free(bind_path);
 
     const target_path = if (extractOptionalStringByNames(args_obj, &[_][]const u8{"target_path"})) |value| blk: {


### PR DESCRIPTION
## Summary
- bind the core workspace services needed by external workers (`chat`, `jobs`, `events`) into default templates
- use the local process uid/gid for namespace attrs so mounted workspaces behave more like normal filesystems
- reduce FUSE cache TTLs for dynamic workspace paths
- switch durable agent homes to `/home/<agent-id>`
- fix readdir pagination compatibility by accepting both `next_cookie` and `next` in router/session refresh paths
- allow admin workspace status responses to include the fs auth token needed for mounting
- use the correct default export name for workspace mounts

## Verification
- `zig build test`
- `git diff --check`
- live mounted-workspace smoke against isolated Spiderweb: workspace create, mount, service discovery, home claim, worker registration, and queued job visibility

## Notes
- this includes the live mounted-workspace fixes that were still local after the earlier external-worker work
- it also addresses the concrete pagination bug affecting `/services/jobs` proxy refreshes