### PR TITLE
Refresh install and ops scripts for workspace host flow

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,9 @@
 # PIPED (non-interactive, uses defaults):
 #   curl -fsSL https://raw.githubusercontent.com/DeanoC/Spiderweb/main/install.sh | bash
 #
-# NON-INTERACTIVE with options:
-#   curl ... | SPIDERWEB_PROVIDER=openai-codex SPIDERWEB_AGENT=ziggy bash
+# NON-INTERACTIVE with defaults:
+#   curl ... | SPIDERWEB_NON_INTERACTIVE=1 bash
+#
 # Pin installer repo refs (for testing non-main branches):
 #   curl .../install.sh | SPIDERWEB_GIT_REF=feat/foo ZSS_GIT_REF=feat/bar bash
 
@@ -576,7 +577,7 @@ if [[ "$INSTALL_SYSTEMD" == "true" ]]; then
     # Create service file content
     if [[ "$SYSTEMD_SCOPE" == "system" ]]; then
         SERVICE_FILE="[Unit]
-Description=Spiderweb AI Agent Gateway
+Description=Spiderweb Workspace Host
 After=network.target
 
 [Service]
@@ -596,7 +597,7 @@ WantedBy=multi-user.target"
         log_success "System service installed and started"
     else
         SERVICE_FILE="[Unit]
-Description=Spiderweb AI Agent Gateway
+Description=Spiderweb Workspace Host
 After=network.target
 
 [Service]
@@ -723,9 +724,9 @@ print_auth_tokens_summary
 echo ""
 echo "Next steps:"
 echo "  1. Reveal auth tokens: spiderweb-config auth status --reveal"
-echo "  2. Create a workspace: spiderweb-control workspace_create '{\"name\":\"Demo\",\"vision\":\"Mounted workspace\"}'"
-echo "  3. Mount it: spiderweb-fs-mount --workspace-url ws://127.0.0.1:${CURRENT_PORT}/ --auth-token <admin-token> --workspace-id <workspace-id> mount ./workspace"
-echo "  4. Start Spider Monkey: spider-monkey run --workspace-root ./workspace"
+echo "  2. Create a dev workspace: spiderweb-control --url ws://127.0.0.1:${CURRENT_PORT}/ --auth-token <admin-token> workspace_create '{\"name\":\"Demo\",\"vision\":\"Mounted workspace\",\"template_id\":\"dev\"}'"
+echo "  3. Mount it: spiderweb-fs-mount --workspace-url ws://127.0.0.1:${CURRENT_PORT}/ --auth-token <admin-or-user-token> --workspace-id <workspace-id> mount ./workspace"
+echo "  4. Start Spider Monkey: spider-monkey run --agent-id spider-monkey --worker-id spider-monkey-a --workspace-root ./workspace"
 if [[ "$INSTALL_ZSS" == "true" ]]; then
     echo ""
     echo "Optional GUI/tooling:"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -33,9 +33,10 @@ sudo journalctl -u spiderweb -f
 After the service is running:
 
 ```bash
+export SPIDERWEB_CONFIG=/etc/spiderweb/config.json
 spiderweb-config auth status --reveal
-spiderweb-control --url ws://127.0.0.1:18790/ --auth-token <admin-token> workspace_create '{"name":"Demo","vision":"Mounted workspace"}'
-spiderweb-fs-mount --workspace-url ws://127.0.0.1:18790/ --auth-token <admin-token> --workspace-id <workspace-id> mount ./workspace
+spiderweb-control --url ws://127.0.0.1:18790/ --auth-token <admin-token> workspace_create '{"name":"Demo","vision":"Mounted workspace","template_id":"dev"}'
+spiderweb-fs-mount --workspace-url ws://127.0.0.1:18790/ --auth-token <admin-or-user-token> --workspace-id <workspace-id> mount ./workspace
 ```
 
 Then start an external worker, for example Spider Monkey, against the mounted directory.

--- a/scripts/acheron-chaos-restart.sh
+++ b/scripts/acheron-chaos-restart.sh
@@ -5,8 +5,10 @@ SPIDERWEB_URL="${SPIDERWEB_URL:-ws://127.0.0.1:18790/}"
 SPIDERWEB_WORKSPACE_ID="${SPIDERWEB_WORKSPACE_ID:-system}"
 SPIDERWEB_WORKSPACE_TOKEN="${SPIDERWEB_WORKSPACE_TOKEN:-}"
 SPIDERWEB_AUTH_TOKEN="${SPIDERWEB_AUTH_TOKEN:-}"
-SPIDERWEB_AUTH_TOKEN_FILE="${SPIDERWEB_AUTH_TOKEN_FILE:-$HOME/.local/share/ziggy-spiderweb/.spiderweb-ltm/auth_tokens.json}"
+SPIDERWEB_AUTH_TOKEN_FILE="${SPIDERWEB_AUTH_TOKEN_FILE:-}"
+SPIDERWEB_CONFIG_BIN="${SPIDERWEB_CONFIG_BIN:-spiderweb-config}"
 SPIDERWEB_SERVICE="${SPIDERWEB_SERVICE:-spiderweb.service}"
+SPIDERWEB_SERVICE_SCOPE="${SPIDERWEB_SERVICE_SCOPE:-auto}"
 
 CHAOS_ITERATIONS="${CHAOS_ITERATIONS:-30}"
 CHAOS_RESTART_AT="${CHAOS_RESTART_AT:-10}"
@@ -24,7 +26,6 @@ require_bin() {
 }
 
 require_bin systemctl
-require_bin systemd-run
 require_bin spiderweb-control
 require_bin spiderweb-fs-mount
 require_bin jq
@@ -33,6 +34,56 @@ require_bin timeout
 spiderweb_control_bin="$(command -v spiderweb-control)"
 spiderweb_fs_mount_bin="$(command -v spiderweb-fs-mount)"
 timeout_bin="$(command -v timeout)"
+
+resolve_auth_token_file() {
+    if command -v "$SPIDERWEB_CONFIG_BIN" >/dev/null 2>&1; then
+        local resolved
+        resolved="$("$SPIDERWEB_CONFIG_BIN" auth path 2>/dev/null | tr -d '\r' | tail -n 1 || true)"
+        if [[ -n "$resolved" ]]; then
+            printf '%s\n' "$resolved"
+            return
+        fi
+    fi
+    printf '%s\n' "$HOME/.local/share/ziggy-spiderweb/.spiderweb-ltm/auth_tokens.json"
+}
+
+resolve_service_scope() {
+    case "$SPIDERWEB_SERVICE_SCOPE" in
+        user|system)
+            printf '%s\n' "$SPIDERWEB_SERVICE_SCOPE"
+            ;;
+        auto)
+            if systemctl --user show "$SPIDERWEB_SERVICE" >/dev/null 2>&1; then
+                printf 'user\n'
+            elif systemctl show "$SPIDERWEB_SERVICE" >/dev/null 2>&1; then
+                printf 'system\n'
+            else
+                printf 'system\n'
+            fi
+            ;;
+        *)
+            echo "error: invalid SPIDERWEB_SERVICE_SCOPE: $SPIDERWEB_SERVICE_SCOPE" >&2
+            exit 2
+            ;;
+    esac
+}
+
+run_service_ctl() {
+    local action="$1"
+    shift || true
+    if [[ "$service_scope" == "user" ]]; then
+        systemctl --user "$action" "$SPIDERWEB_SERVICE" "$@"
+    elif [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
+        systemctl "$action" "$SPIDERWEB_SERVICE" "$@"
+    else
+        sudo systemctl "$action" "$SPIDERWEB_SERVICE" "$@"
+    fi
+}
+
+if [[ -z "$SPIDERWEB_AUTH_TOKEN_FILE" ]]; then
+    SPIDERWEB_AUTH_TOKEN_FILE="$(resolve_auth_token_file)"
+fi
+service_scope="$(resolve_service_scope)"
 
 if [[ -z "$SPIDERWEB_AUTH_TOKEN" && -f "$SPIDERWEB_AUTH_TOKEN_FILE" ]]; then
     SPIDERWEB_AUTH_TOKEN="$(jq -r '.admin_token // .user_token // empty' "$SPIDERWEB_AUTH_TOKEN_FILE" 2>/dev/null || true)"
@@ -48,7 +99,7 @@ if [[ "$CHAOS_RESTART_AT" -lt 2 || "$CHAOS_RESTART_AT" -gt $((CHAOS_ITERATIONS -
 fi
 
 run_unit_cmd() {
-    systemd-run --user --wait --collect --pipe --quiet "$timeout_bin" "${CHAOS_TIMEOUT_SEC}s" "$@"
+    "$timeout_bin" "${CHAOS_TIMEOUT_SEC}s" "$@"
 }
 
 control_args=(--url "$SPIDERWEB_URL")
@@ -78,6 +129,7 @@ fi
 
 echo "chaos log: $CHAOS_LOG_PATH"
 echo "service: $SPIDERWEB_SERVICE"
+echo "service scope: $service_scope"
 echo "url: $SPIDERWEB_URL"
 echo "workspace: $SPIDERWEB_WORKSPACE_ID"
 echo "iterations: $CHAOS_ITERATIONS restart_at: $CHAOS_RESTART_AT interval_ms: $CHAOS_INTERVAL_MS"
@@ -103,7 +155,7 @@ restart_done=0
 for i in $(seq 1 "$CHAOS_ITERATIONS"); do
     if [[ "$i" -eq "$CHAOS_RESTART_AT" ]]; then
         echo "$(date --iso-8601=seconds) event=restart-start service=$SPIDERWEB_SERVICE" | tee -a "$CHAOS_LOG_PATH"
-        systemctl --user restart "$SPIDERWEB_SERVICE"
+        run_service_ctl restart
         echo "$(date --iso-8601=seconds) event=restart-done service=$SPIDERWEB_SERVICE" | tee -a "$CHAOS_LOG_PATH"
         restart_done=1
     fi

--- a/scripts/acheron-multi-node-runtime.sh
+++ b/scripts/acheron-multi-node-runtime.sh
@@ -5,7 +5,8 @@ SPIDERWEB_URL="${SPIDERWEB_URL:-ws://127.0.0.1:18790/}"
 SPIDERWEB_WORKSPACE_ID="${SPIDERWEB_WORKSPACE_ID:-}"
 SPIDERWEB_WORKSPACE_TOKEN="${SPIDERWEB_WORKSPACE_TOKEN:-}"
 SPIDERWEB_AUTH_TOKEN="${SPIDERWEB_AUTH_TOKEN:-}"
-SPIDERWEB_AUTH_TOKEN_FILE="${SPIDERWEB_AUTH_TOKEN_FILE:-$HOME/.local/share/ziggy-spiderweb/.spiderweb-ltm/auth_tokens.json}"
+SPIDERWEB_AUTH_TOKEN_FILE="${SPIDERWEB_AUTH_TOKEN_FILE:-}"
+SPIDERWEB_CONFIG_BIN="${SPIDERWEB_CONFIG_BIN:-spiderweb-config}"
 EXPECTED_NODES="${EXPECTED_NODES:-}"
 EXPECTED_SERVICES="${EXPECTED_SERVICES:-}"
 HARNESS_TIMEOUT_SEC="${HARNESS_TIMEOUT_SEC:-90}"
@@ -26,6 +27,22 @@ require_bin spiderweb-control
 require_bin spiderweb-fs-mount
 require_bin jq
 require_bin timeout
+
+resolve_auth_token_file() {
+    if command -v "$SPIDERWEB_CONFIG_BIN" >/dev/null 2>&1; then
+        local resolved
+        resolved="$("$SPIDERWEB_CONFIG_BIN" auth path 2>/dev/null | tr -d '\r' | tail -n 1 || true)"
+        if [[ -n "$resolved" ]]; then
+            printf '%s\n' "$resolved"
+            return
+        fi
+    fi
+    printf '%s\n' "$HOME/.local/share/ziggy-spiderweb/.spiderweb-ltm/auth_tokens.json"
+}
+
+if [[ -z "$SPIDERWEB_AUTH_TOKEN_FILE" ]]; then
+    SPIDERWEB_AUTH_TOKEN_FILE="$(resolve_auth_token_file)"
+fi
 
 if [[ -z "$SPIDERWEB_AUTH_TOKEN" && -f "$SPIDERWEB_AUTH_TOKEN_FILE" ]]; then
     SPIDERWEB_AUTH_TOKEN="$(jq -r '.admin_token // .user_token // empty' "$SPIDERWEB_AUTH_TOKEN_FILE" 2>/dev/null || true)"

--- a/scripts/acheron-namespace-smoke.ps1
+++ b/scripts/acheron-namespace-smoke.ps1
@@ -11,7 +11,7 @@ $SpiderwebUrl = if ($env:SPIDERWEB_URL) { $env:SPIDERWEB_URL } else { "ws://127.
 $SpiderwebWorkspaceId = $env:SPIDERWEB_WORKSPACE_ID
 $SpiderwebWorkspaceToken = $env:SPIDERWEB_WORKSPACE_TOKEN
 $SpiderwebAuthToken = $env:SPIDERWEB_AUTH_TOKEN
-$SpiderwebAuthTokenFile = if ($env:SPIDERWEB_AUTH_TOKEN_FILE) { $env:SPIDERWEB_AUTH_TOKEN_FILE } else { Join-Path $HOME ".local\share\ziggy-spiderweb\.spiderweb-ltm\auth_tokens.json" }
+$SpiderwebAuthTokenFile = $env:SPIDERWEB_AUTH_TOKEN_FILE
 $SpiderwebAgentId = $env:SPIDERWEB_AGENT_ID
 $SpiderwebSessionKey = $env:SPIDERWEB_SESSION_KEY
 $SpiderwebMountBackend = if ($env:SPIDERWEB_MOUNT_BACKEND) { $env:SPIDERWEB_MOUNT_BACKEND } else { "auto" }
@@ -62,6 +62,30 @@ function Require-Command {
     if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
         throw "required binary not found: $Name"
     }
+}
+
+function Resolve-AuthTokenFile {
+    param([string]$ExplicitPath)
+
+    if ($ExplicitPath) {
+        return $ExplicitPath
+    }
+
+    $configCmd = Get-Command "spiderweb-config" -ErrorAction SilentlyContinue
+    if ($configCmd) {
+        try {
+            $resolved = (& $configCmd.Source auth path 2>$null | Select-Object -Last 1)
+            if ($resolved) {
+                $trimmed = [string]$resolved
+                if ($trimmed.Trim().Length -gt 0) {
+                    return $trimmed.Trim()
+                }
+            }
+        } catch {
+        }
+    }
+
+    return (Join-Path $HOME ".local\share\ziggy-spiderweb\.spiderweb-ltm\auth_tokens.json")
 }
 
 function Invoke-FsMountRaw {
@@ -155,6 +179,7 @@ function Test-PathSafe {
 
 $FsMountBin = if ($SpiderwebFsMountBin) { $SpiderwebFsMountBin } else { Resolve-Binary "spiderweb-fs-mount" }
 Require-Command "ConvertFrom-Json"
+$SpiderwebAuthTokenFile = Resolve-AuthTokenFile -ExplicitPath $SpiderwebAuthTokenFile
 
 if (-not $SpiderwebAuthToken -and (Test-Path $SpiderwebAuthTokenFile)) {
     $tokenJson = Get-Content -LiteralPath $SpiderwebAuthTokenFile -Raw | ConvertFrom-Json
@@ -192,7 +217,13 @@ for ($attempt = 1; $attempt -le $SmokeConnectRetries; $attempt += 1) {
 }
 
 $status = $statusText | ConvertFrom-Json
-Write-Host "namespace workspace: $($status.project_id)"
+if ($status.PSObject.Properties.Name -contains "workspace_id" -and $status.workspace_id) {
+    Write-Host "namespace workspace: $($status.workspace_id)"
+} elseif ($status.PSObject.Properties.Name -contains "project_id" -and $status.project_id) {
+    Write-Host "namespace workspace: $($status.project_id)"
+} else {
+    Write-Host "namespace workspace: (none)"
+}
 Write-Host "namespace agent: $($status.agent_id)"
 
 foreach ($path in @("/agents", "/nodes", "/global")) {

--- a/scripts/acheron-namespace-smoke.sh
+++ b/scripts/acheron-namespace-smoke.sh
@@ -8,7 +8,8 @@ SPIDERWEB_URL="${SPIDERWEB_URL:-ws://127.0.0.1:18790/}"
 SPIDERWEB_WORKSPACE_ID="${SPIDERWEB_WORKSPACE_ID:-}"
 SPIDERWEB_WORKSPACE_TOKEN="${SPIDERWEB_WORKSPACE_TOKEN:-}"
 SPIDERWEB_AUTH_TOKEN="${SPIDERWEB_AUTH_TOKEN:-}"
-SPIDERWEB_AUTH_TOKEN_FILE="${SPIDERWEB_AUTH_TOKEN_FILE:-$HOME/.local/share/ziggy-spiderweb/.spiderweb-ltm/auth_tokens.json}"
+SPIDERWEB_AUTH_TOKEN_FILE="${SPIDERWEB_AUTH_TOKEN_FILE:-}"
+SPIDERWEB_CONFIG_BIN="${SPIDERWEB_CONFIG_BIN:-spiderweb-config}"
 SPIDERWEB_AGENT_ID="${SPIDERWEB_AGENT_ID:-}"
 SPIDERWEB_SESSION_KEY="${SPIDERWEB_SESSION_KEY:-}"
 SPIDERWEB_MOUNT_BACKEND="${SPIDERWEB_MOUNT_BACKEND:-auto}"
@@ -64,6 +65,22 @@ fi
 require_bin jq
 require_bin timeout
 
+resolve_auth_token_file() {
+    if command -v "$SPIDERWEB_CONFIG_BIN" >/dev/null 2>&1; then
+        local resolved
+        resolved="$("$SPIDERWEB_CONFIG_BIN" auth path 2>/dev/null | tr -d '\r' | tail -n 1 || true)"
+        if [[ -n "$resolved" ]]; then
+            printf '%s\n' "$resolved"
+            return
+        fi
+    fi
+    printf '%s\n' "$HOME/.local/share/ziggy-spiderweb/.spiderweb-ltm/auth_tokens.json"
+}
+
+if [[ -z "$SPIDERWEB_AUTH_TOKEN_FILE" ]]; then
+    SPIDERWEB_AUTH_TOKEN_FILE="$(resolve_auth_token_file)"
+fi
+
 if [[ -z "$SPIDERWEB_AUTH_TOKEN" && -f "$SPIDERWEB_AUTH_TOKEN_FILE" ]]; then
     SPIDERWEB_AUTH_TOKEN="$(jq -r '.admin_token // .user_token // empty' "$SPIDERWEB_AUTH_TOKEN_FILE" 2>/dev/null || true)"
 fi
@@ -106,9 +123,9 @@ while true; do
     attempt=$((attempt + 1))
 done
 
-resolved_project_id="$(jq -r '.project_id // empty' <<<"$status_json")"
+resolved_workspace_id="$(jq -r '.workspace_id // .project_id // empty' <<<"$status_json")"
 resolved_agent_id="$(jq -r '.agent_id // empty' <<<"$status_json")"
-echo "namespace workspace: ${resolved_project_id:-"(none)"}"
+echo "namespace workspace: ${resolved_workspace_id:-"(none)"}"
 echo "namespace agent: ${resolved_agent_id:-"(none)"}"
 
 for path in /agents /nodes /global; do

--- a/scripts/acheron-smoke.sh
+++ b/scripts/acheron-smoke.sh
@@ -5,13 +5,15 @@ SPIDERWEB_URL="${SPIDERWEB_URL:-ws://127.0.0.1:18790/}"
 SPIDERWEB_WORKSPACE_ID="${SPIDERWEB_WORKSPACE_ID:-}"
 SPIDERWEB_WORKSPACE_TOKEN="${SPIDERWEB_WORKSPACE_TOKEN:-}"
 SPIDERWEB_AUTH_TOKEN="${SPIDERWEB_AUTH_TOKEN:-}"
-SPIDERWEB_AUTH_TOKEN_FILE="${SPIDERWEB_AUTH_TOKEN_FILE:-$HOME/.local/share/ziggy-spiderweb/.spiderweb-ltm/auth_tokens.json}"
+SPIDERWEB_AUTH_TOKEN_FILE="${SPIDERWEB_AUTH_TOKEN_FILE:-}"
+SPIDERWEB_CONFIG_BIN="${SPIDERWEB_CONFIG_BIN:-spiderweb-config}"
 EXPECTED_NODES="${EXPECTED_NODES:-}"
 SMOKE_TIMEOUT_SEC="${SMOKE_TIMEOUT_SEC:-15}"
 SMOKE_FAIL_ON_DEGRADED="${SMOKE_FAIL_ON_DEGRADED:-1}"
 SMOKE_CONNECT_RETRIES="${SMOKE_CONNECT_RETRIES:-8}"
 SMOKE_RETRY_DELAY_MS="${SMOKE_RETRY_DELAY_MS:-500}"
 SPIDERWEB_SERVICE="${SPIDERWEB_SERVICE:-spiderweb.service}"
+SPIDERWEB_SERVICE_SCOPE="${SPIDERWEB_SERVICE_SCOPE:-auto}"
 
 require_bin() {
     if ! command -v "$1" >/dev/null 2>&1; then
@@ -25,8 +27,52 @@ require_bin spiderweb-fs-mount
 require_bin jq
 require_bin timeout
 
-if command -v systemctl >/dev/null 2>&1 && systemctl show "$SPIDERWEB_SERVICE" >/dev/null 2>&1; then
+resolve_auth_token_file() {
+    if command -v "$SPIDERWEB_CONFIG_BIN" >/dev/null 2>&1; then
+        local resolved
+        resolved="$("$SPIDERWEB_CONFIG_BIN" auth path 2>/dev/null | tr -d '\r' | tail -n 1 || true)"
+        if [[ -n "$resolved" ]]; then
+            printf '%s\n' "$resolved"
+            return
+        fi
+    fi
+    printf '%s\n' "$HOME/.local/share/ziggy-spiderweb/.spiderweb-ltm/auth_tokens.json"
+}
+
+resolve_service_scope() {
+    case "$SPIDERWEB_SERVICE_SCOPE" in
+        user|system)
+            printf '%s\n' "$SPIDERWEB_SERVICE_SCOPE"
+            ;;
+        auto)
+            if command -v systemctl >/dev/null 2>&1 && systemctl --user show "$SPIDERWEB_SERVICE" >/dev/null 2>&1; then
+                printf 'user\n'
+            elif command -v systemctl >/dev/null 2>&1 && systemctl show "$SPIDERWEB_SERVICE" >/dev/null 2>&1; then
+                printf 'system\n'
+            else
+                printf 'unknown\n'
+            fi
+            ;;
+        *)
+            echo "error: invalid SPIDERWEB_SERVICE_SCOPE: $SPIDERWEB_SERVICE_SCOPE" >&2
+            exit 2
+            ;;
+    esac
+}
+
+if [[ -z "$SPIDERWEB_AUTH_TOKEN_FILE" ]]; then
+    SPIDERWEB_AUTH_TOKEN_FILE="$(resolve_auth_token_file)"
+fi
+
+service_scope="$(resolve_service_scope)"
+if [[ "$service_scope" == "user" ]]; then
+    restrict_namespaces="$(systemctl --user show "$SPIDERWEB_SERVICE" -p RestrictNamespaces --value 2>/dev/null || true)"
+elif [[ "$service_scope" == "system" ]]; then
     restrict_namespaces="$(systemctl show "$SPIDERWEB_SERVICE" -p RestrictNamespaces --value 2>/dev/null || true)"
+else
+    restrict_namespaces=""
+fi
+if [[ -n "$restrict_namespaces" ]]; then
     if [[ "$restrict_namespaces" == "yes" ]]; then
         echo "error: $SPIDERWEB_SERVICE has RestrictNamespaces=yes; sandbox runtime/bwrap will fail" >&2
         echo "hint: reinstall with scripts/install-systemd.sh or set RestrictNamespaces=false in the unit" >&2
@@ -87,9 +133,9 @@ availability_total="$(jq -r '.payload.availability.mounts_total // 0' <<<"$reply
 availability_online="$(jq -r '.payload.availability.online // 0' <<<"$reply")"
 availability_degraded="$(jq -r '.payload.availability.degraded // 0' <<<"$reply")"
 availability_missing="$(jq -r '.payload.availability.missing // 0' <<<"$reply")"
-project_id_resolved="$(jq -r '.payload.project_id // "(none)"' <<<"$reply")"
+workspace_id_resolved="$(jq -r '.payload.workspace_id // .payload.project_id // "(none)"' <<<"$reply")"
 
-echo "workspace id: ${project_id_resolved}"
+echo "workspace id: ${workspace_id_resolved}"
 echo "availability: online=${availability_online}/${availability_total} degraded=${availability_degraded} missing=${availability_missing}"
 
 if [[ "$availability_total" -eq 0 ]]; then

--- a/scripts/full-reset.sh
+++ b/scripts/full-reset.sh
@@ -34,6 +34,8 @@ USER_PATHS=(
     "$TARGET_HOME/.local/share/ziggy"
     "$TARGET_HOME/.local/bin/spiderweb"
     "$TARGET_HOME/.local/bin/spiderweb-config"
+    "$TARGET_HOME/.local/bin/spiderweb-control"
+    "$TARGET_HOME/.local/bin/spiderweb-fs-mount"
     "/tmp/spiderweb.log"
 )
 
@@ -46,6 +48,8 @@ SYSTEM_PATHS=(
     "/opt/spiderweb"
     "/usr/local/bin/spiderweb"
     "/usr/local/bin/spiderweb-config"
+    "/usr/local/bin/spiderweb-control"
+    "/usr/local/bin/spiderweb-fs-mount"
 )
 
 if [ -n "$BASE_DIR" ]; then

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -134,6 +134,7 @@ install_files() {
     ln -sf "$INSTALL_DIR/bin/spiderweb" /usr/local/bin/spiderweb
     ln -sf "$INSTALL_DIR/bin/spiderweb-config" /usr/local/bin/spiderweb-config
     ln -sf "$INSTALL_DIR/bin/spiderweb-control" /usr/local/bin/spiderweb-control
+    ln -sf "$INSTALL_DIR/bin/spiderweb-fs-mount" /usr/local/bin/spiderweb-fs-mount
 
     log_info "Binaries installed ✓"
 }
@@ -277,11 +278,13 @@ print_summary() {
     echo "  Stop:      sudo systemctl stop $SERVICE_NAME"
     echo "  Status:    sudo systemctl status $SERVICE_NAME"
     echo "  Logs:      sudo journalctl -u $SERVICE_NAME -f"
-    echo "  Config:    sudo spiderweb-config config"
+    echo "  Config:    sudo env SPIDERWEB_CONFIG=$CONFIG_DIR/config.json spiderweb-config config"
+    echo "  Auth:      sudo env SPIDERWEB_CONFIG=$CONFIG_DIR/config.json spiderweb-config auth status --reveal"
     echo ""
     echo "Notes:"
     echo "  - Spiderweb now runs as a workspace host only."
     echo "  - Create and mount workspaces with spiderweb-control and spiderweb-fs-mount."
+    echo "  - Export SPIDERWEB_CONFIG=$CONFIG_DIR/config.json when using spiderweb-config outside the service."
     echo "  - External workers such as Spider Monkey own model/provider credentials."
     echo ""
 }

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -4,12 +4,26 @@
 # Run as root or with sudo
 #
 
-set -e
+set -euo pipefail
 
 INSTALL_USER="${INSTALL_USER:-spiderweb}"
-INSTALL_DIR="${INSTALL_DIR:-/opt/spiderweb}"
-CONFIG_DIR="${CONFIG_DIR:-/etc/spiderweb}"
 SERVICE_NAME="${SERVICE_NAME:-spiderweb}"
+BASE_DIR="${SPIDERWEB_BASE_DIR:-${BASE_DIR:-}}"
+if [ -n "$BASE_DIR" ]; then
+    INSTALL_DIR_DEFAULT="$BASE_DIR/opt/spiderweb"
+    CONFIG_DIR_DEFAULT="$BASE_DIR/etc/spiderweb"
+    DATA_DIR_DEFAULT="$BASE_DIR/var/lib/spiderweb"
+    LOG_DIR_DEFAULT="$BASE_DIR/var/log/spiderweb"
+else
+    INSTALL_DIR_DEFAULT="/opt/spiderweb"
+    CONFIG_DIR_DEFAULT="/etc/spiderweb"
+    DATA_DIR_DEFAULT="/var/lib/spiderweb"
+    LOG_DIR_DEFAULT="/var/log/spiderweb"
+fi
+INSTALL_DIR="${INSTALL_DIR:-$INSTALL_DIR_DEFAULT}"
+CONFIG_DIR="${CONFIG_DIR:-$CONFIG_DIR_DEFAULT}"
+DATA_DIR="${DATA_DIR:-$DATA_DIR_DEFAULT}"
+LOG_DIR="${LOG_DIR:-$LOG_DIR_DEFAULT}"
 
 # Colors
 RED='\033[0;31m'
@@ -44,8 +58,8 @@ read_confirm() {
     echo "  - User: $INSTALL_USER"
     echo "  - Directory: $INSTALL_DIR"
     echo "  - Config: $CONFIG_DIR"
-    echo "  - Logs: /var/log/spiderweb"
-    echo "  - Data: /var/lib/spiderweb"
+    echo "  - Logs: $LOG_DIR"
+    echo "  - Data: $DATA_DIR"
     echo ""
     read -p "Are you sure? [y/N] " -n 1 -r
     echo ""
@@ -74,6 +88,8 @@ remove_files() {
     rm -rf "$INSTALL_DIR"
     rm -f /usr/local/bin/spiderweb
     rm -f /usr/local/bin/spiderweb-config
+    rm -f /usr/local/bin/spiderweb-control
+    rm -f /usr/local/bin/spiderweb-fs-mount
     
     # Config (backup first if exists)
     if [ -d "$CONFIG_DIR" ]; then
@@ -84,8 +100,8 @@ remove_files() {
     fi
     
     # Logs and data
-    rm -rf /var/log/spiderweb
-    rm -rf /var/lib/spiderweb
+    rm -rf "$LOG_DIR"
+    rm -rf "$DATA_DIR"
 }
 
 remove_user() {

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -4,9 +4,17 @@
 # Run as root or with sudo
 #
 
-set -e
+set -euo pipefail
 
 SERVICE_NAME="${SERVICE_NAME:-spiderweb}"
+BASE_DIR="${SPIDERWEB_BASE_DIR:-${BASE_DIR:-}}"
+if [ -n "$BASE_DIR" ]; then
+    INSTALL_DIR_DEFAULT="$BASE_DIR/opt/spiderweb"
+else
+    INSTALL_DIR_DEFAULT="/opt/spiderweb"
+fi
+INSTALL_DIR="${INSTALL_DIR:-$INSTALL_DIR_DEFAULT}"
+BINARIES=(spiderweb spiderweb-config spiderweb-control spiderweb-fs-mount)
 
 log_info() {
     echo -e "\033[0;32m[INFO]\033[0m $1"
@@ -34,8 +42,19 @@ rm -rf zig-out .zig-cache
 zig build -Doptimize=ReleaseSafe
 
 log_info "Installing binaries..."
-cp zig-out/bin/spiderweb /opt/spiderweb/bin/
-cp zig-out/bin/spiderweb-config /opt/spiderweb/bin/
+if [ ! -d "$INSTALL_DIR/bin" ]; then
+    log_error "Install directory not found: $INSTALL_DIR/bin"
+    exit 1
+fi
+
+for bin in "${BINARIES[@]}"; do
+    if [ ! -x "zig-out/bin/$bin" ]; then
+        log_error "Missing build artifact: zig-out/bin/$bin"
+        exit 1
+    fi
+    cp "zig-out/bin/$bin" "$INSTALL_DIR/bin/"
+    ln -sf "$INSTALL_DIR/bin/$bin" "/usr/local/bin/$bin"
+done
 
 log_info "Restarting service..."
 systemctl start "$SERVICE_NAME"


### PR DESCRIPTION
## Summary
- update `install.sh` and `scripts/README.md` to match the workspace-host, template-aware flow
- refresh install/update/uninstall/reset scripts so they manage the full current Spiderweb binary set
- harden smoke and chaos scripts around auth token discovery, workspace-first status output, and systemd scope detection

## Testing
- bash -n install.sh scripts/*.sh
- git diff --check
- zig build
- zig build test
